### PR TITLE
Replaced env vars with config parser (issue #1)

### DIFF
--- a/botScript.py
+++ b/botScript.py
@@ -111,12 +111,13 @@ def is_command(word: str):
 
 # Take a command and its parameters and return the corresponding response
 def handle_command(command: str, params: list[str]):
-
-    match command:
-        case '!help':
+    
+    # Command is parsed to remove command prefix
+    match command[1:]:
+        case 'help':
             pretty_commands = '\n'.join(COMMANDS)
             return f'These are some of the commands I can respond to:\n`{pretty_commands}`' # Backticks (`) format text as code in discord
-        case '!meetingtime':
+        case 'meetingtime':
             return f'The current meeting time is:\nEvery Wednesday at 5:30pm'
 
 

--- a/botScript.py
+++ b/botScript.py
@@ -1,25 +1,33 @@
-import os
+from configparser import ConfigParser
 import discord
 
 # ----- Load and check variables ----- #
-# Load environment variables
-TOKEN = os.getenv('DISCORD_TOKEN')
-GUILD_ID = os.getenv('DISCORD_GUILD_ID')
 
-# If either environment variable isn't present, print an error and quit
+# Initialize ConfigParser and open config.ini
+config = ConfigParser()
+config.read('config.ini')
+
+# Load variables
+TOKEN = config['SETTINGS']['token']
+GUILD_ID = config['SETTINGS']['guild_id']
+
+COMMAND_CHAR = config['SETTINGS']['command_prefix']
+COMMANDS = [f'{COMMAND_CHAR}help', f'{COMMAND_CHAR}meetingtime']
+
+# If any of these variables aren't present, print an error and quit
 if TOKEN == None:
-    print('Error: No DISCORD_TOKEN environment variable present.')
+    print('Error: No DISCORD_TOKEN present in config.ini')
     quit()
 
 if GUILD_ID == None:
-    print('Error: No DISCORD_GUILD_ID environment variable present.')
+    print('Error: No DISCORD_GUILD_ID present in config.ini')
     quit()
 
+if COMMAND_CHAR == None:
+    print('Error: No COMMAND_PREFIX present in config.ini')
+    quit()
+    
 GUILD_ID = int(GUILD_ID)
-
-# Load variables
-COMMAND_CHAR = '!'
-COMMANDS = [f'{COMMAND_CHAR}help', f'{COMMAND_CHAR}meetingtime']
 
 # Set the intents of the bot, to be given to the `Client` constructor
 intents = discord.Intents.default()
@@ -46,7 +54,7 @@ async def on_ready():
 
 # Runs whenever a member joins
 @client.event
-async def on_member_join(member):
+async def on_member_join(member: discord.Member):
 
     # Print to terminal
     print(f'{member.name} joined the server.')

--- a/botScript.py
+++ b/botScript.py
@@ -84,10 +84,8 @@ async def on_message(message: discord.Message):
                 
     # If the message mentions the bot and the first word in the message is any string in the tuple, bot will say hello
     elif client.user in message.mentions and message.content.split()[0].lower() in ('hello', 'hi'):
-
-        # The name of the user who sent the message, if a nickname is present then it will use that instead
-        sender = message.author.name if message.author.nick == None else message.author.nick
-        await client.get_channel(message.channel.id).send(f'Hello {sender}!')
+        
+        await client.get_channel(message.channel.id).send(f'Hello {message.author.display_name}!')
 
 
 # ----- Generic functions ----- #

--- a/botScript.py
+++ b/botScript.py
@@ -81,10 +81,13 @@ async def on_message(message: discord.Message):
 
                 # Log command and parameters
                 print(f'Command: {command}\nParameters: {params}')
+                
+    # If the message mentions the bot and the first word in the message is any string in the tuple, bot will say hello
+    elif client.user in message.mentions and message.content.split()[0].lower() in ('hello', 'hi'):
 
-    elif client.user in message.mentions:
-        # If the message mentions the bot, say hello
-        await client.get_channel(message.channel.id).send('Hello')
+        # The name of the user who sent the message, if a nickname is present then it will use that instead
+        sender = message.author.name if message.author.nick == None else message.author.nick
+        await client.get_channel(message.channel.id).send(f'Hello {sender}!')
 
 
 # ----- Generic functions ----- #

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,7 @@
 [SETTINGS]
 token = 
 guild_id = 
+command_prefix = !
 
 [CUSTOM COMMANDS]
 

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,6 @@
+[SETTINGS]
+token = 
+guild_id = 
+
+[CUSTOM COMMANDS]
+


### PR DESCRIPTION
I got rid of the need for `environment variables` and added `configparser`. This also means that I added a `config.ini` file with the settings you mentioned in issue #1 . `[CUSTOM COMMANDS]` is included but it's empty.

I also added a setting to change the command prefix in `config.ini`. Like `TOKEN` and `GUILD_ID`, `COMMAND_CHAR` is now checked to see if it's present. Since you wanted the bot to be customizable I thought this would be a good idea.

With `COMMAND_CHAR` now being dynamic, it required me to edit `handle_command()` because the match-case statement was written for only `!` as the command prefix.

I added type hinting for the `member` parameter in `on_member_join()`