### PR TITLE
Bot detecting phrases and words instead of only words in GREETINGS

### DIFF
--- a/botScript.py
+++ b/botScript.py
@@ -99,7 +99,7 @@ async def on_message(message: discord.Message):
                 print(f'Command: {command}\nParameters: {params}')
 
     # If the message mentions the bot and the first word in the message is a "greeting", bot will say hello
-    elif client.user in message.mentions and message.content.split()[0].lower() in GREETINGS:
+    elif client.user in message.mentions and message.content.lower().startswith(tuple(GREETINGS)):
         await client.get_channel(message.channel.id).send(f'Hello {message.author.display_name}!')
 
 


### PR DESCRIPTION
**Unable to test this**
When cloning your repo, I am unable to run the program through the script. I get this error: `KeyError: 'settings'`

I don't know why I am getting this error, I have my `config.ini` setup just fine, and I did not change anything in the code besides what's in the PR.

I did make my own test cases for the condition so the following code should work.

**Regarding to PR ( issue #11 )**
Bot will now recognize phrases instead of only single words

The condition for detecting a greeting was changed to see if the user's message started with any items in `GREETINGS` by iterating through a tuple casting of `GREETINGS`