### PR TITLE
fix: skip sending empty or whitespace-only responses from bot

### DIFF
--- a/botScript.py
+++ b/botScript.py
@@ -137,8 +137,8 @@ async def on_message(message: discord.Message):
                 # Get the proper response
                 response = await handle_command(command, params, message, client, config)
 
-                # If the command generated a response
-                # Check if the response is not None and is not just whitespace
+                # If the command generated a valid response (not None or empty/whitespace),
+                # send it to the channel. Otherwise, skip sending.
                 if response is not None and response.strip():
                     # Send the response to the same channel where the message was received
                     await client.get_channel(message.channel.id).send(response)

--- a/botScript.py
+++ b/botScript.py
@@ -138,9 +138,13 @@ async def on_message(message: discord.Message):
                 response = await handle_command(command, params, message, client, config)
 
                 # If the command generated a response
-                if response != None:
-                    # Respond in the channel of the original message
+                # Check if the response is not None and is not just whitespace
+                if response is not None and response.strip():
+                    # Send the response to the same channel where the message was received
                     await client.get_channel(message.channel.id).send(response)
+                else:
+                    # Do nothing if the response is None or empty (after stripping whitespace)
+                    pass  # Optional: can be omitted or used for logging/debugging
 
                 # Log command and parameters
                 print(f'Command: {command}\nParameters: {params}')


### PR DESCRIPTION
This pull request implements a safeguard to prevent the Discord bot from sending empty or whitespace-only messages in response. This ensures cleaner message flow and avoids unnecessary or confusing bot responses.